### PR TITLE
website link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Free software for citizen participation.
 
 [See code on github](https://github.com/consuldemocracy/consuldemocracy)
 
-Visit live website on [http://consuldemocracy.org/en/](http://consuldemocracy.org/en/)
-
+Visit live website on [http://consuldemocracy.org](https://consuldemocracy.org/)
 ## Notes
 
 For CSS grid we use [Simple Grid](http://simplegrid.io)


### PR DESCRIPTION
The consul democracy website was redirecting to a 404. That will now be fixed.